### PR TITLE
Improved the deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Chemhacktica
+# Deprecated
+
+We are now using the [ASKCOS](https://askcos-docs.mit.edu/guide/1-Introduction/1.1-Introduction.html) [repositories](https://gitlab.com/mlpds_mit/askcosv2/askcos-docs/-/wikis/5.1%20ASKCOS%20Overview#repository-organization) for the backend of Chemhacktica and [our fork](https://github.com/FourThievesVinegar/askcos-vue-nginx) of ASKCOS's front end.
+
+#### Chemhacktica
 
 Scrape - to scrape for casrn's 
 


### PR DESCRIPTION
I learned about https://synth.fourthievesvinegar.org/ at a talk recently.  I wound up here, hoping to learn more about it (so I could decide whether I have the skillset to volunteer).  Internet connectivity was spotty at the time, so I didn't immediately resolve this question:

> what is askcos?

I believe that this change will make it easier for people that are searching for "Chemhacktica" to find the underlying code.